### PR TITLE
feat: Add MinIO service with Docker Compose and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,64 @@
+# Docker volumes and data directories
+*/data/
+*/logs/
+*/config/
+*/.env
+
+# MinIO specific
+minio/data/
+minio/.minio.sys/
+
+# Database data directories
+mysql/data/
+mariadb/data/
+postgres/data/
+mongodb/data/
+redis/data/
+
+# Nginx logs
+nginx/logs/
+
+# WordPress uploads and cache
+wordpress/wp-content/uploads/
+wordpress/wp-content/cache/
+
+# Environment files with sensitive data
+.env
+.env.local
+.env.production
+.env.development
+
+# Docker specific
+.dockerignore
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Temporary folders
+tmp/
+temp/

--- a/minio/.gitignore
+++ b/minio/.gitignore
@@ -1,0 +1,6 @@
+# MinIO data and system files
+data/
+.minio.sys/
+
+# Environment files
+.env

--- a/minio/docker-compose.yaml
+++ b/minio/docker-compose.yaml
@@ -1,0 +1,13 @@
+services:
+  minio:
+    image: minio/minio
+    container_name: minio
+    ports:
+      - "9050:9000"
+      - "9051:9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin123
+    volumes:
+      - ./data:/data
+    command: server /data --console-address ":9001"


### PR DESCRIPTION
Added a root .gitignore and a MinIO-specific .gitignore to exclude data, logs, config, and environment files. Introduced a docker-compose.yaml for MinIO service setup, exposing ports 9050 and 9051, and mounting a local data directory.