### PR TITLE
feat: Add Actual Budget docker-compose setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ postgres/data/
 mongodb/data/
 redis/data/
 
+budgetactual/actual-data/
+
 # Nginx logs
 nginx/logs/
 

--- a/budgetactual/docker-compose.yaml
+++ b/budgetactual/docker-compose.yaml
@@ -1,0 +1,9 @@
+services:
+  actual:
+    image: actualbudget/actual-server:latest
+    container_name: actual
+    restart: unless-stopped
+    ports:
+      - "7001:5006"
+    volumes:
+      - ./actual-data:/data


### PR DESCRIPTION
Added a docker-compose.yaml for running Actual Budget server in the budgetactual directory. Updated .gitignore to exclude the actual-data directory used for persistent data storage.